### PR TITLE
AWSEG-25772 Forcing Lombok @Data annotation for new model classes

### DIFF
--- a/spot_java_style.xml
+++ b/spot_java_style.xml
@@ -5,7 +5,7 @@
 
 <module name="Checker">
   <module name="SuppressionFilter">
-    <property name="file" value="/suppressions.xml"/>
+    <property name="file" value="https://raw.githubusercontent.com/spotinst/.github/1f207fbbd267d70c569d9f05ccb59733e5a6a8c7/suppressions.xml"/>
     <property name="optional" value="false"/>
   </module>
   <module name="SuppressWarningsFilter"/>

--- a/spot_java_style.xml
+++ b/spot_java_style.xml
@@ -271,7 +271,7 @@
       <property name="arrayInitIndent" value="4"/>
     </module>
     <module name="AbbreviationAsWordInName">
-      <property name="ignoreFinal" value="false"/>
+      <property name="ignoreFinal" value="true"/>
       <property name="allowedAbbreviationLength" value="3"/>
       <property name="tokens"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,

--- a/spot_java_style.xml
+++ b/spot_java_style.xml
@@ -4,6 +4,10 @@
           "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+  <module name="SuppressionFilter">
+    <property name="file" value="/suppressions.xml"/>
+    <property name="optional" value="false"/>
+  </module>
   <module name="SuppressWarningsFilter"/>
 
   <property name="charset" value="UTF-8"/>
@@ -393,6 +397,12 @@
       <property name="checkFormat" value="$1"/>
       <!-- The check is suppressed in the next line of code after the comment -->
       <property name="influenceFormat" value="1"/>
+    </module>
+    <module name="MatchXpath">
+      <property name="id" value="LombokCheck"/>
+      <property name="query" value="//CLASS_DEF/MODIFIERS[not(./ANNOTATION/IDENT[@text='Data'])]"/>
+      <message key="matchxpath.match"
+               value="Each model class should have use '@Data' Lombok annotation."/>
     </module>
   </module>
 </module>

--- a/spot_java_style.xml
+++ b/spot_java_style.xml
@@ -5,7 +5,7 @@
 
 <module name="Checker">
   <module name="SuppressionFilter">
-    <property name="file" value="https://raw.githubusercontent.com/spotinst/.github/1f207fbbd267d70c569d9f05ccb59733e5a6a8c7/suppressions.xml"/>
+    <property name="file" value="https://github.com/spotinst/.github/blob/main/suppressions.xml"/>
     <property name="optional" value="false"/>
   </module>
   <module name="SuppressWarningsFilter"/>

--- a/spot_java_style.xml
+++ b/spot_java_style.xml
@@ -5,8 +5,8 @@
 
 <module name="Checker">
   <module name="SuppressionFilter">
-    <property name="file" value="https://github.com/spotinst/.github/blob/main/suppressions.xml"/>
-    <property name="optional" value="false"/>
+    <property name="file" value="https://raw.githubusercontent.com/spotinst/.github/main/supressions.xml"/>
+    <property name="optional" value="true"/>
   </module>
   <module name="SuppressWarningsFilter"/>
 

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -2,4 +2,5 @@
         "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
     <suppress files="^((?!model).)*$" id="LombokCheck" />
+    <suppress files="[\\/]src[\\/]test[\\/].*" checks="LineLength" />
 </suppressions>

--- a/suppressions.xml
+++ b/suppressions.xml
@@ -1,0 +1,5 @@
+<!DOCTYPE suppressions PUBLIC "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+<suppressions>
+    <suppress files="^((?!model).)*$" id="LombokCheck" />
+</suppressions>


### PR DESCRIPTION
AWSEG-25772
- Forcing Lombok `@Data` annotation for new model classes
- Ignoring final fields from the limit of 3 consecutive capital letters
- Suppressing the Line Length check for test packages


# Jira Ticket


 [AWSEG-25772](https://spotinst.atlassian.net/browse/AWSEG-25772)

# Demo


# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 


[AWSEG-25772]: https://spotinst.atlassian.net/browse/AWSEG-25772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ